### PR TITLE
Fedora and openSUSE update

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -176,7 +176,7 @@
 			</div>
 			<div id="fedora" class="subsection">
 				<h2>Fedora</h2>
-				<p>OpenSCAD is available in Fedora 17+ official repositories. So installing OpenSCAD on Fedora boils down to running the following command:</p>
+				<p>OpenSCAD is available in Fedora official repositories. So installing OpenSCAD on Fedora boils down to running the following command:</p>
 				<pre>
 					<code># yum install openscad</code>
 				</pre>
@@ -186,7 +186,7 @@
 				</pre>
 			</div>
 			<div id="opensuse" class="subsection">
-				<h2>openSuse</h2>
+				<h2>openSUSE</h2>
 				<p>OpenSCAD is available from <a href="http://software.opensuse.org/download.html?project=graphics&package=openscad" target="_blank">software.opensuse.org</a></p>
 			</div>
 			<div id="other-linux" class="subsection">
@@ -297,6 +297,8 @@
 					<small>x64 (64-bit) - tgz archive -</small><small id="LIN64_SNAPSHOT_SIZE">?? MB</small>
 				</button>
 				</a>
+				<h3>Fedora</h3>
+				<p>There is a repository with OpenSCAD development snapshots on <a href="http://copr.fedoraproject.org/coprs/churchyard/openscad-devel/">copr.fedoraproject.org</a>.</p>
 			</div>
 
 		</section>


### PR DESCRIPTION
- Remove 17+ from Fedora info (even F18 is currently EOL)
- Add link to development repository for Fedora
- Change openSuse to openSUSE (proper spelling)
