### PR TITLE
cheatsheet: add links to the manual

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -19,7 +19,7 @@
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Variables">var</a> = <a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Values_and_Data_Types">value</a>;</code>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Modules">module</a> name(&hellip;) { &hellip; }<br/>
 				name();</code>
-				<code>function name(&hellip;) = &hellip;<br/>
+				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/User-Defined_Functions">function</a> name(&hellip;) = &hellip;<br/>
 				name();</code>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Include_Statement">include</a> &lt;&hellip;.scad&gt;</code>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Include_Statement">use</a> &lt;&hellip;.scad&gt;</code>


### PR DESCRIPTION
I was not able to find documentation for the `function' keyword,
otherwise everything is linked.
