### PR TITLE
scale parameter added in linear_extrude on cheatsheet

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -152,7 +152,7 @@
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Conditional_and_Iterator_Functions#If_Statement">if</a> (&hellip;) { &hellip; }</code>
 				<s><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Conditional_and_Iterator_Functions#Assign_Statement">assign</a> (&hellip;) { &hellip; }</code></s>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Importing_Geometry#import">import</a>("&hellip;.stl")</code>
-				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#Linear_Extrude">linear_extrude</a>(height,center,convexity,twist,slices)</code>
+				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#Linear_Extrude">linear_extrude</a>(height,center,convexity,twist,slices,scale)</code>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#Rotate_Extrude">rotate_extrude</a>(angle,convexity)</code>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#Surface">surface</a>(file = "&hellip;.dat",center,convexity)</code>
 				<code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#3D_to_2D_Projection">projection</a>(cut)</code>


### PR DESCRIPTION
(missing on cheatsheet) Scale parameter is on the linked doc and working with the 2015.03 version
