### PR TITLE
Remove Fedora 21 link

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -209,7 +209,6 @@
 				<pre>
 					<code># yum install openscad-MCAD</code>
 				</pre>
-				<p>Please note that you'll find OpenSCAD 2014.03 in Fedora 21 and lower. In case you'd like to use 2015.03 in Fedora 21, you can use <a href="https://copr.fedoraproject.org/coprs/churchyard/openscad-2015.03/">a Copr repo with it</a>.</a></p>
 			</div>
 			<div id="opensuse" class="subsection">
 				<h2>openSUSE</h2>


### PR DESCRIPTION
Fedora 21 is history (the linked copr repo wouldn't work anyway)