### PR TITLE
change google analytics for gdpr

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -26,6 +26,8 @@
           var _gaq = _gaq || [];
           _gaq.push(['_setAccount', 'UA-26999768-1']);
           _gaq.push(['_setDomainName', 'openscad.org']);
+          _gaq.push(['_gat._anonymizeIp']); // For gdpr
+          _gaq.push(['_gat._forceSSL']); // Send all hits using SSL, even from insecure (HTTP) pages.
           _gaq.push(['_trackPageview']);
           
           (function() {


### PR DESCRIPTION
gdpr = General Data Protection Regulation (EU)

This is only a small part to fulfill the regulation.

Code snipped from:
https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat#_gat._anonymizeIp