### PR TITLE
Auto select scheme for fetching flattr.com

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -3,7 +3,7 @@
         var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
         s.type = 'text/javascript';
         s.async = true;
-        s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto&button=compact';
+        s.src = '//api.flattr.com/js/0.6/load.js?mode=auto&button=compact';
         t.parentNode.insertBefore(s, t);
     })();
 /* ]]> */


### PR DESCRIPTION
Chrome blocks fetching the flattr.com script because it is from an insecure site when viewing https://www.openscad.org/downloads.html (which is loaded securely). This change (removing the scheme name) should result in loading it via http if the page was loaded as http, and via https if the page was loaded as https.

Alternately, I can explicitly set the scheme to https.

Note that there is another error on download.html related to loading coinwidget. I can send a fix if you like.