### PR TITLE
cheatsheet: don't force the dull color on links

### DIFF
--- a/cheatsheet/css/main.css
+++ b/cheatsheet/css/main.css
@@ -6,10 +6,6 @@ body {
 	padding: 0.6em;
 }
 
-a {
-	color: #447FFF;
-}
-
 h1 {
 	font-family: "UbuntuMonoBold", "Ubuntu Mono", 'courier new', monospace, sans-serif;
 	font-weight: normal;


### PR DESCRIPTION
dull colors are worse in print and on displays against the sunlight, better at nothing