### PR TITLE
Added information on lists and indexing to cheatsheet

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -56,10 +56,10 @@
         <dl>
           <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Vectors">list = [&hellip;, &hellip;, &hellip;];</a></code></dt>
           <dd>&nbsp;&nbsp;create a list</dd>
-          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Vectors">var = list[2];</a></code></dt>
+          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Indexing_elements_within_vectors">var = list[2];</a></code></dt>
           <dd>&nbsp;&nbsp;index a list (from 0)</dd>
-          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Vectors">var = list.z;</a></code></dt>
-          <dd>&nbsp;&nbsp;dot notation indexing</dd>
+          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Dot_notation_indexing">var = list.z;</a></code></dt>
+          <dd>&nbsp;&nbsp;dot notation indexing (x/y/z)</dd>
         </dl>
       </article>
       <article>

--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -52,6 +52,17 @@
         </dl>
       </article>
       <article>
+        <h2>Lists</h2>
+        <dl>
+          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Vectors">list = [&hellip;, &hellip;, &hellip;];</a></code></dt>
+          <dd>&nbsp;&nbsp;create a list</dd>
+          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Vectors">var = list[2];</a></code></dt>
+          <dd>&nbsp;&nbsp;index a list (from 0)</dd>
+          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/General#Vectors">var = list.z;</a></code></dt>
+          <dd>&nbsp;&nbsp;dot notation indexing</dd>
+        </dl>
+      </article>
+      <article>
         <h2>Special variables</h2>
         <dl>
           <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#.24fa.2C_.24fs_and_.24fn">$fa</a></code></dt>


### PR DESCRIPTION
Adding information on lists and indexing to cheat sheet. Fits nicely on the left:

![image](https://user-images.githubusercontent.com/12807051/99920775-a7f3b400-2d1d-11eb-9cf8-3f4a491a23e3.png)

I think it is nice to draw attention to the dot notation indexing as it is clean, but hard to find from the cheatsheet which is the first place I go or send anyone who is new to OpenSCAD.