### PR TITLE
Update downloads.html

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -169,7 +169,7 @@
 			<div class="subsection">
 				<p>OpenSCAD is also available on <a href="https://brew.sh/" target="_blank">Homebrew</a>:</p>
 				<pre>
-					<code>$ brew cask install openscad</code>
+					<code>$ brew install openscad</code>
 				</pre>
 			</div>
 		</section>


### PR DESCRIPTION
Updated Homebrew command, `brew cask install` is depreciated, things can be installed with `brew install` _cask-name_ or brew install --cask _cask-name_