### PR TITLE
Update link to "children" in Wikibooks.

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -80,7 +80,7 @@
           <dd>viewport translation</dd>
           <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#.24vpr.2C_.24vpt_and_.24vpd">$vpd</a></code></dt>
           <dd>viewport camera distance</dd>
-          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/User-Defined_Functions_and_Modules#children">$children</a></code></dt>
+          <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/User-Defined_Functions_and_Modules#Children">$children</a></code></dt>
           <dd>&nbsp;number of module children</dd>
           <dt><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#$preview">$preview</a></code></dt>
           <dd>&nbsp;true in F5 preview, false for F6</dd>


### PR DESCRIPTION
Raised the case of the link to the page for "children" in Wikibooks as the previous link took you to the page as a whole.