### PR TITLE
fix for links to wiki

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -132,9 +132,9 @@
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#cylinder">cylinder</a>(h,r1|d1,r2|d2,center)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#polyhedron">polyhedron</a>(points, faces, convexity)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Importing_Geometry#import">import</a>("&hellip;.<span class="tooltip">ext<span class="tooltiptext">formats: STL|OFF|AMF|3MF</span></span>", convexity)</code>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#Linear_Extrude">linear_extrude</a>(height,center,convexity,twist,slices)</code>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#Rotate_Extrude">rotate_extrude</a>(angle,convexity)</code>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#Surface">surface</a>(file = "&hellip;.<span class="tooltip">ext<span class="tooltiptext">formats: DAT|PNG</span></span>",center,convexity)</code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#linear_extrude">linear_extrude</a>(height,center,convexity,twist,slices)</code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#rotate_extrude">rotate_extrude</a>(angle,convexity)</code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#surface">surface</a>(file = "&hellip;.<span class="tooltip">ext<span class="tooltiptext">formats: DAT|PNG</span></span>",center,convexity)</code>
       </article>
       <article>
         <h2>Transformations</h2>
@@ -203,8 +203,8 @@
       </article>
       <article>
         <h2>Other</h2>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#Echo_Statements">echo</a>(&hellip;)</code>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#Render">render</a>(convexity)</code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#echo">echo</a>(&hellip;)</code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#render">render</a>(convexity)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/User-Defined_Functions_and_Modules#Children">children</a>([idx])</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#assert">assert</a>(condition, message)</code>
         <s><code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Conditional_and_Iterator_Functions#Assign_Statement">assign</a> (&hellip;) { &hellip; }</code></s>
@@ -219,7 +219,7 @@
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/String_Functions#str">str</a></code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/String_Functions#chr">chr</a></code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/String_Functions#ord">ord</a></code>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#Search">search</a></code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#search">search</a></code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#OpenSCAD_Version">version</a></code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#OpenSCAD_Version">version_num</a></code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Other_Language_Features#parent_module.28n.29_and_.24parent_modules">parent_module</a>(idx)</code>


### PR DESCRIPTION
Capital letter causes # link to headline to fail.  As other topics are all in small letter (except For ) small letter as in the command itself should be used here too.