### PR TITLE
Change app.element.io link to matrix.to link.

### DIFF
--- a/community.html
+++ b/community.html
@@ -150,7 +150,7 @@
       <ul>
         <li>Join via the libera.chat <a href="https://web.libera.chat/?channel=#openscad">web chat</a> (KiwiIRC)</li>
         <li>Connect with an IRC client to <a href="irc:openscad@irc.libera.chat" target="_blank">#openscad</a> on <a href="ircs://irc.libera.chat:6697">irc.libera.chat</a> +6697 (TLS)</li>
-        <li>The chat room is also available via <a href="https://matrix.org/">Matrix</a> as <a href="https://app.element.io/#/room/#openscad:libera.chat">#openscad:libera.chat</a></li>
+        <li>The chat room is also available via <a href="https://matrix.org/">Matrix</a> as <a href="https://matrix.to/#/#openscad:libera.chat">#openscad:libera.chat</a></li>
         <li>Additional documentation on how to connect can be found at <a href="https://libera.chat/guides">https://libera.chat/guides</a></li>
       </ul>
   </section>


### PR DESCRIPTION
Linking directly to app.element.io is a bad practice, as it assumes that everyone uses the same client. Using matrix.to is encouraged instead as it allows users to select their client from the list, as well as choose which web client instance to use.