### PR TITLE
fix: some typos

### DIFF
--- a/documentation-books.html
+++ b/documentation-books.html
@@ -359,7 +359,7 @@
           <li>ISBN: 978-1-90-792099-8</li>
         </ul>
         </div>
-        <p>Watch the video review by the Autor on <a href="https://www.youtube.com/watch?v=qvQ8qlLgEc0">YouTube</a></p>
+        <p>Watch the video review by the Author on <a href="https://www.youtube.com/watch?v=qvQ8qlLgEc0">YouTube</a></p>
         <p>Buy directly from the Author:
           <a href="https://www.elektor.com/technical-modeling-with-openscad">Book</a> /
           <a href="https://www.elektor.com/technical-modeling-with-openscad-e-book">PDF</a>

--- a/news.html
+++ b/news.html
@@ -110,7 +110,7 @@
         <a href="https://fosstodon.org/@OpenSCAD">Mastodon</a> from the Twitter bio again.
       </p>
       <p>
-        So here are the links to the 2 offical accounts that are currently active:
+        So here are the links to the 2 official accounts that are currently active:
         <ul>
           <li>Mastodon: <a href="https://fosstodon.org/@OpenSCAD">@OpenSCAD@fosstodon.org</a></li>
           <li>Twitter: <a href="https://twitter.com/openscad">openscad</a></li>
@@ -286,7 +286,7 @@
         <p>But it's worth highlighting also some of the not so obvious smaller features which
         might improve the editing workflow.
         <ul>
-          <li><i>Bookmarks</i> - Ctrl+F2 to toogle bookmarks, F2 / Shift+F2 for jumping to next/previous bookmark.</li>
+          <li><i>Bookmarks</i> - Ctrl+F2 to toggle bookmarks, F2 / Shift+F2 for jumping to next/previous bookmark.</li>
           <li><i>Changing numbers via mouse</i> - Similar to ALT+Cursor-Up/Down, numbers can be modified by placing the cursor at the number and using the mouse scroll wheel while pressing the ALT key.</li>
           <li><i>Code snippets</i> - Insert often used code snippets using ALT+Insert or via editor context menu, custom templates can be added as simple files.</li>
         </ul>
@@ -300,7 +300,7 @@
         joined the OpenSCAD team for a couple of month and have helped to make some of those
         new features possible (details on those projects can be found in the
         <a href="https://github.com/openscad/openscad/issues?q=label%3A%22Tag%3A+GSoC%22">project reports</a>
-        on github). It's been a nice time and an opportunity learn and disucss ideas.</p>
+        on github). It's been a nice time and an opportunity learn and discuss ideas.</p>
 
         <p>The source code, as well as binaries for Mac OS X, Windows and Linux are ready
         for <a href="downloads.html">download</a>.</p>
@@ -575,7 +575,7 @@
                     via a simple user interface and save sets of parameter presets.
 		    While this feature has been available in the development snapshots for
                     a while now, there were lots of improvements lately to both usability of the
-                    interface as well as correctly handling of parameters hints specfied in the
+                    interface as well as correctly handling of parameters hints specified in the
                     model source code.</dd>
                     <dt>3MF Import/Export</dt>
                     <dd>The 3D Manufacturing Format (3MF) as defined by the <a href="https://3mf.io/">
@@ -586,7 +586,7 @@
                     As additional reason for this format being a very attractive option is that
                     its <a href=https://3mf.io/specification/">Specification</a> and
                     <a href="https://github.com/3MFConsortium/lib3mf/">reference implementation</a>
-                    are freely available and useable in Open Source projects.</dd>
+                    are freely available and usable in Open Source projects.</dd>
                     </dl>
 		    <br clear="all"/>
 		    <p>At this point all of the features are available in the latest development
@@ -612,7 +612,7 @@
 		      <li><a href="https://github.com/openscad/openscad/wiki/Project:-Improve-Text-Editor">Improve text editor with new IDE style features</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#openscad-standard-library">OpenSCAD Standard Library</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-OpenGL-rendering">OpenGL framework</a></li>
-                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistant-caching">Persistent Caching</a></li>
+                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistent-caching">Persistent Caching</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Multi-threaded-geometry-rendering">Multi-threaded Geometry Evaluation</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Survey-of-CSG-algorithms">Survey and prototype of CSG algorithms</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#issue-handling">Issue handling and bug squashing</a></li>
@@ -637,7 +637,7 @@
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-DXF-import-and-export">Improve DXF Import and Export</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#openscad-standard-library">OpenSCAD Standard Library</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-OpenGL-rendering">OpenGL framework</a></li>
-                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistant-caching">Persistent Caching</a></li>
+                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistent-caching">Persistent Caching</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Multi-threaded-geometry-rendering">Multi-threaded Geometry Evaluation</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Survey-of-CSG-algorithms">Survey and prototype of CSG algorithms</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#issue-handling">Issue handling and bug squashing</a></li>
@@ -682,7 +682,7 @@
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-DXF-import-and-export">Improve DXF Import and Export</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#openscad-standard-library">OpenSCAD Standard Library</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-OpenGL-rendering">OpenGL framework</a></li>
-                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistant-caching">Persistent Caching</a></li>
+                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistent-caching">Persistent Caching</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Multi-threaded-geometry-rendering">Multi-threaded Geometry Evaluation</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Survey-of-CSG-algorithms">Survey and prototype of CSG algorithms</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#issue-handling">Issue handling and bug squashing</a></li>
@@ -767,7 +767,7 @@
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-DXF-import-and-export">Improve DXF Import and Export</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#openscad-standard-library">OpenSCAD Standard Library</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Improve-OpenGL-rendering">OpenGL framework</a></li>
-                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistant-caching">Persistent Caching</a></li>
+                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistent-caching">Persistent Caching</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Multi-threaded-geometry-rendering">Multi-threaded Geometry Evaluation</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Project%3A-Survey-of-CSG-algorithms">Survey and prototype of CSG algorithms</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#issue-handling">Issue handling and bug squashing</a></li>
@@ -883,7 +883,7 @@
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-user-interface-brushup">User interface brushup</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-improve-dxf-import">Improve DXF import</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-opengl-framework">OpenGL framework</a></li>
-                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-persistant-caching">Persistant caching</a></li>
+                      <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-persistant-caching">Persistent caching</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-multi-threaded-geometry-evaluation">Multi-threaded Geometry Evaluation</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-web-front-end">Web front-end</a></li>
                       <li><a href="https://github.com/openscad/openscad/wiki/Ideas:-GSoC-2014#wiki-larger-tasks-for-particularly-experienced-people">Larger tasks for particularly experienced people</a></li>


### PR DESCRIPTION
Typo in wiki already fixed:

```diff
- https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistant-caching
+ https://github.com/openscad/openscad/wiki/Ideas-for-Development-Tasks#persistent-caching