### PR TITLE
Correct link to polyhedron

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -116,7 +116,7 @@
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#cube">cube</a>([width,depth,height], center)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#cylinder">cylinder</a>(h,r|d,center)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#cylinder">cylinder</a>(h,r1|d1,r2|d2,center)</code>
-        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#polyhedron">polyhedron</a>(points, faces, convexity)</code>
+        <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Constructed_Solids#Polyhedron()_Object_Module">polyhedron</a>(points, faces, convexity)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Importing_Geometry#import">import</a>("&hellip;.<span class="tooltip">ext<span class="tooltiptext">formats: STL|OFF|AMF|3MF</span></span>", convexity)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#linear_extrude">linear_extrude</a>(height,center,convexity,twist,slices)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#rotate_extrude">rotate_extrude</a>(angle,convexity)</code>


### PR DESCRIPTION
The previous link ponited to a non existant section on the Primitive_Solids page.