### PR TITLE
First argument to text() is text, not t.

### DIFF
--- a/cheatsheet/index.html
+++ b/cheatsheet/index.html
@@ -106,8 +106,8 @@
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#polygon">polygon</a>([points])</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#polygon">polygon</a>([points],[paths])</code>
         <code>
-          <a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Text">text</a>(t, size, font, direction, language, script,
-          <br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;halign, valign, spacing)
+          <a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Text">text</a>(text,size,font,direction,language,script,
+          <br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;halign,valign,spacing)
         </code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Importing_Geometry#import">import</a>("&hellip;.<span class="tooltip">ext<span class="tooltiptext">formats: DXF|SVG</span></span>", convexity)</code>
         <code><a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#3D_to_2D_Projection">projection</a>(cut)</code>


### PR DESCRIPTION
Overall style is no spaces after commas in arg lists. Fixes openscad/openscad#5686.

I fixed this a while back in the snapshot cheat sheet.  Perhaps we should add `t` as an alias for `text`, but the primary name has always been `text`.  That's doubly true for the release cheat sheet (which is what I'm updating here), where the program is never going to change.