### PR TITLE
Update brew reference

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -158,7 +158,7 @@
 			<div class="subsection">
 				<p>OpenSCAD is also available on <a href="https://brew.sh/" target="_blank">Homebrew</a> (<a href="https://formulae.brew.sh/cask/openscad#default">check version</a>):</p>
 				<pre>
-					<code>$ brew install openscad</code>
+					<code>$ brew install openscad@snapshot</code>
 				</pre>
 			</div>
 		</section>


### PR DESCRIPTION
Openscad is vended by a slightly different brew cask now: https://formulae.brew.sh/cask/openscad@snapshot