### PR TITLE
Add some text describing the Cheat Sheet

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -189,7 +189,20 @@
     </section>
 
 		<section id="cheat-sheet">
-			<h1>Cheat Sheet</h1>
+			<h1><a href="cheatsheet/index.html" target="_blank">Cheat Sheet</a></h1>
+                        The <a href="cheatsheet/index.html" target="_blank">Cheat Sheet</a> is a
+                        quick reference to the language syntax and built-in modules and functions,
+                        with links to the main documentation.  It is also available from inside the
+                        program, via the Help menu.
+                        <p>
+                        <!--
+                            Better text here would be good, or maybe we could figure out how to
+                            automatically create a current PNG, or could include the actual cheat
+                            sheet here.
+                        -->
+                        NOTE:  the image below is only a link!  The cheat sheet is a separate web
+                        page.
+                        <p>
 			<a href="cheatsheet/index.html" target="_blank"><img class="imgLink" src="assets/img/openSCAD_cheat_sheet.png" width="680"/></a>
 		</section>	
 	</article>


### PR DESCRIPTION
... and clarifying that the image on the documentation page is just a link.

A new user didn't immediately realize that there was more to see there.  Also, it seemed useful to explicitly mention that you can get to it from Help/Cheat Sheet.
