### PR TITLE
Move the link farm to the top, to the same line as the header.

### DIFF
--- a/cheatsheet/snapshot.html
+++ b/cheatsheet/snapshot.html
@@ -14,6 +14,13 @@
   <header>
     <h1 class="title" style="position:relative;"><span class="green">Open</span>SCAD</h1>
     <h2>(<a href="https://openscad.org/downloads.html#snapshots">dev snapshot</a>)</h2>
+    <a href="https://openscad.org/" target="_blank">Official website</a>
+    | <a href="https://github.com/openscad/openscad" target="_blank">Code</a>
+    | <a href="https://github.com/openscad/openscad/issues" target="_blank">Issues</a>
+    | <a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual" target="_blank">Manual</a>
+    | <a href="https://github.com/openscad/MCAD" target="_blank">MCAD library</a>
+    | <a href="https://openscad.org/community.html#forum" target="_blank">Mailing list</a>
+    | <a href="http://fablabamersfoort.nl/book/openscad" target="_blank">Other links</a>
   </header>
   <section>
     <section>
@@ -273,19 +280,6 @@
     </section>
             
     <br clear="all"/>
-    
-    <section>
-      <article class="info">
-          <em>Links:</em>
-          <a href="https://openscad.org/" target="_blank">Official website</a>
-          | <a href="https://github.com/openscad/openscad" target="_blank">Code</a>
-          | <a href="https://github.com/openscad/openscad/issues" target="_blank">Issues</a>
-          | <a href="https://en.wikibooks.org/wiki/OpenSCAD_User_Manual" target="_blank">Manual</a>
-          | <a href="https://github.com/openscad/MCAD" target="_blank">MCAD library</a>
-          | <a href="https://openscad.org/community.html#forum" target="_blank">Mailing list</a>
-          | <a href="http://fablabamersfoort.nl/book/openscad" target="_blank">Other links</a>
-      </article>
-    </section>
   </section>
 
   <footer>


### PR DESCRIPTION
It occurred to me that the link farm line at the bottom of the cheat sheet would fit to the right of the header, reducing the vertical size of the page, and would arguably be even better there.

I don't know of an easy way to view a github HTML page, but here's what it looks like at full width:

> <img width="1620" height="190" alt="image" src="https://github.com/user-attachments/assets/1ac1a45c-a33b-4872-bea4-6fc279882fac" />

Note that github will squash the image here to fit.

I can't say that I'm super happy with the vertical spacing if you narrow the window further.  It's usable, but not aesthetically pleasing.  I expect that there's a way to move the entire line down if space requires, but I'd rather not mess with that until I get some buy-in on the overall concept.  Let me know what you think.  Here's what it looks like when taken narrower.

> <img width="1006" height="192" alt="image" src="https://github.com/user-attachments/assets/4ff25bf7-4553-4f85-a3fa-713419dfbdf9" />

> <img width="523" height="218" alt="image" src="https://github.com/user-attachments/assets/6a3aa953-bac2-4a5d-8b27-f1f0647d2a12" />