### PR TITLE
Add OpenSCAD Studio to related projects

### DIFF
--- a/about.html
+++ b/about.html
@@ -116,6 +116,7 @@
 					<li><a href="https://implicitcad.org">ImplicitCAD</a></li>
 					<li><a href="https://gilesbathgate.com/category/rapcad/">RapCAD</a></li>
 					<li><a href="https://openjscad.xyz">OpenJSCAD</a></li>
+					<li><a href="https://openscad-studio.pages.dev/">OpenSCAD Studio</a></li>
 					<li><a href="https://www.blockscad3d.com/editor/">BlocksCAD</a></li>
 				</ul>
 		</section>


### PR DESCRIPTION
## Summary
- Add OpenSCAD Studio to the About page Related Projects list.

## Why
OpenSCAD Studio gives OpenSCAD users a modern browser-accessible editor for writing, previewing, and iterating on `.scad` models without first installing a desktop toolchain. Listing it on the OpenSCAD website helps makers and newcomers discover a maintained OpenSCAD-focused workbench alongside other community projects already collected there.

This project is an editor/workbench rather than a reusable OpenSCAD code library, so the existing Related Projects section is a better fit than the Libraries page.

## Validation
- Ran `git diff --check`.